### PR TITLE
Fixed many links across all applicable files

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -1,3 +1,3 @@
 <html>
-<meta http-equiv="refresh" content="0; url=http://communi.github.com/doc/latest">
+<meta http-equiv="refresh" content="0; url=https://communi.github.io/doc/latest">
 </html>

--- a/doc/latest/index.html
+++ b/doc/latest/index.html
@@ -1,3 +1,3 @@
 <html>
-<meta http-equiv="refresh" content="0; url=http://communi.github.com/doc/3.6">
+<meta http-equiv="refresh" content="0; url=https://communi.github.io/doc/3.6">
 </html>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
             <div class="btn-group">
               <a href="https://github.com/communi/libcommuni" class="btn btn-info">Source code<br></a>
               <a href="https://github.com/communi/libcommuni/issues" class="btn btn-info">Issue tracker</a>
-              <a href="http://communi.github.com/doc" class="btn btn-info">Documentation</a>
+              <a href="https://communi.github.io/doc" class="btn btn-info">Documentation</a>
             </div>
           </li>
         </ul>
@@ -45,7 +45,7 @@
       <div class="marketing">
         <p class="introduction">
           Communi provides a set of tools for enabling
-          <a href="http://en.wikipedia.org/wiki/Internet_Relay_Chat">IRC</a>
+          <a href="https://en.wikipedia.org/wiki/Internet_Relay_Chat">IRC</a>
           connectivity in Qt-based C++ and QML applications.
         </p>
       </div>
@@ -98,9 +98,9 @@
               </td>
               <td>
                 Adds support for IRCv3.2
-                <a href="http://ircv3.net/specs/extensions/batch-3.2.html">batch messages</a>
+                <a href="https://ircv3.net/specs/extensions/batch">batch messages</a>
                 ,
-                <a href="http://communi.github.io/doc/3.5/debugging.html">debug levels and filters</a>
+                <a href="https://communi.github.io/doc/3.5/debugging">debug levels and filters</a>
                 , and a number of new convenience properties to various classes in the IrcCore
                 module.
               </td>
@@ -118,7 +118,7 @@
               </td>
               <td>
                 Adds support for most of the
-                <a href="http://communi.github.io/doc/3.4/ircv3.html">IRCv3.2 extensions</a>
+                <a href="https://communi.github.io/doc/3.4/ircv3">IRCv3.2 extensions</a>
                 .
               </td>
             </tr>
@@ -190,7 +190,7 @@
               <td>
                 Introduces new features including state saving for connections and models,
                 support for IRCv3.2
-                <a href="http://ircv3.net/specs/core/message-tags-3.2.html">message tags</a>
+                <a href="https://ircv3.net/specs/extensions/message-tags">message tags</a>
                 , an auto-completer for GUI clients, and various new properties across
                 the framework.
               </td>
@@ -241,11 +241,11 @@
               </td>
               <td>
                 Features
-                <a href="http://communi.github.io/doc/3.0/modules.html">modularized libraries</a>
+                <a href="https://communi.github.io/doc/3.0/modules">modularized libraries</a>
                 , full
-                <a href="http://communi.github.io/doc/3.0/qml.html">QML compatibility</a>
+                <a href="https://communi.github.io/doc/3.0/qml">QML compatibility</a>
                 ,
-                <a href="http://communi.github.io/doc/3.0/usage.html#namespace">namespace support</a>
+                <a href="https://communi.github.io/doc/3.0/usage#namespace">namespace support</a>
                 and more.
               </td>
             </tr>
@@ -491,7 +491,7 @@
         <p>
           Communi is free software; you can redistribute and/or modify it under
           the terms of the
-          <a href="http://opensource.org/licenses/BSD-3-Clause">BSD</a>
+          <a href="https://opensource.org/licenses/BSD-3-Clause">BSD</a>
           license.
         </p>
       </div>
@@ -506,7 +506,7 @@
             #communi
           </tt>
           on
-          <a href="http://www.freenode.net">Freenode</a>.
+          <a href="https://www.freenode.net">Freenode</a>.
         </p>
       </div>
       <hr>

--- a/issues/index.html
+++ b/issues/index.html
@@ -1,3 +1,3 @@
 <html>
-<meta http-equiv="refresh" content="0; url=http://github.com/communi/libcommuni/issues">
+<meta http-equiv="refresh" content="0; url=https://github.com/communi/libcommuni/issues">
 </html>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -1,3 +1,3 @@
 <html>
-<meta http-equiv="refresh" content="0; url=http://github.com/communi/communi-meego/wiki/Privacy-Policy">
+<meta http-equiv="refresh" content="0; url=https://github.com/communi/communi-meego/wiki/Privacy-Policy">
 </html>


### PR DESCRIPTION
Most importantly, updated gh pages domain to communi.github.io, as github.com subdomains were looooong deprecated and recently stopped working.
Updated all links to https, because it's not 2013 anymore.
Updated all the links on ircv3.net that returned `301` and further redirects.
